### PR TITLE
Update textTheme property for counter Text

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline1,
             ),
           ],
         ),


### PR DESCRIPTION
Flutter now uses headline1 instead of display1
https://api.flutter.dev/flutter/material/TextTheme-class.html